### PR TITLE
Update ROCm workflow for modern Ubuntu, ROCm versions, and RDNA4 GPUs

### DIFF
--- a/.github/workflows/build-wheels-rocm-full.yml
+++ b/.github/workflows/build-wheels-rocm-full.yml
@@ -89,7 +89,7 @@ jobs:
     env:
       PCKGVER: ${{ inputs.version }}
       # ROCM_VERSION: ${{ matrix.rocm }}
-      ROCM_VERSION: '6.2.4'
+      ROCM_VERSION: '6.4.4'
       AVXVER: ${{ matrix.avx }}
 
     steps:
@@ -166,7 +166,7 @@ jobs:
           $env:VERBOSE = '1'
           $packageVersion = [version]$env:PCKGVER.TrimStart('v')
 
-          $gputargets = 'gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102'
+          $gputargets = 'gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201'
           if ([version]$env:ROCM_VERSION -lt [version]'5.5') {$gputargets = 'gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx1010;gfx1012;gfx1030'}
 
           if ($env:AVXVER -eq 'AVX') {$env:CMAKE_ARGS = "-GNinja -DGGML_HIP=ON -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off -DGPU_TARGETS=$gputargets"}


### PR DESCRIPTION
Fixes #4

The current ROCm build workflow is broken because,
* it targets ubuntu-focal (20.04), but the ROCm 6.x repositories require ubuntu-jammy (22.04)
* the ROCM_VERSION is pinned to an older version that lacks support for newer GPUs
* the build fails due to a CURL dependency in the newer llama.cpp source

These commits resolve those issues and builds the new v0.56.0 tag. In particular,
`.github/workflows/build-wheels-rocm-full.yml`:
* Changed `runs-on: ubuntu-focal` to `runs-on: ubuntu-jammy`
* Updated `ROCM_VERSION` from `6.2.4` to `6.4.4`
* Added `gfx1201` (Radeon RX 9000 series) to the `$gputargets` list
* Added `CMAKE_ARGS = "-DLLAMA_CURL=off $env:CMAKE_ARGS"` to bypass CURL dependency

I've run this modified workflow in my fork and successfully built the v0.56.0 wheel.

I then installed this wheel on my PC (Arch, ROCm 6.4.4) with an AMD Radeon RX 9070 (gfx1201) and confirmed that text-generation-webui successfully loads the model onto the GPU and runs inference. The logs confirm `found 1 ROCm devices` and all layers were offloaded.